### PR TITLE
Update Marshal to use strings.Builder

### DIFF
--- a/marshal_test.go
+++ b/marshal_test.go
@@ -146,6 +146,7 @@ func BenchmarkMarshalNEntries(b *testing.B) {
 	benchmarker(100)
 	benchmarker(1000)
 	benchmarker(10000)
+	benchmarker(100000)
 }
 
 func TestMarshalSingleEntry(t *testing.T) {


### PR DESCRIPTION
Similar to #6, but a smaller modification, added benchmarks, and should make it past the CI. The benchmarks show a pretty significant improvement:

Before:

```console
      Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkMarshalNEntries$ github.com/go-ldap/ldif

      goos: linux
      goarch: amd64
      pkg: github.com/go-ldap/ldif
      cpu: Intel(R) Core(TM) i7-9850H CPU @ 2.60GHz
      BenchmarkMarshalNEntries/marshal_100-12      1000000000  0.001498 ns/op            0 B/op       0 allocs/op
      BenchmarkMarshalNEntries/marshal_1000-12     1000000000    0.1485 ns/op            0 B/op       0 allocs/op
      BenchmarkMarshalNEntries/marshal_10000-12  111295240700           ns/op  94516468448 B/op  349306 allocs/op
      PASS
      ok  github.com/go-ldap/ldif 13.154s
```
After:

```console
      Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkMarshalNEntries$ github.com/go-ldap/ldif

      goos: linux
      goarch: amd64
      pkg: github.com/go-ldap/ldif
      cpu: Intel(R) Core(TM) i7-9850H CPU @ 2.60GHz
      BenchmarkMarshalNEntries/marshal_100-12     1000000000  0.0001769 ns/op  0 B/op  0 allocs/op
      BenchmarkMarshalNEntries/marshal_1000-12    1000000000  0.001784 ns/op   0 B/op  0 allocs/op
      BenchmarkMarshalNEntries/marshal_10000-12   1000000000  0.02262 ns/op    0 B/op  0 allocs/op
      BenchmarkMarshalNEntries/marshal_100000-12  1000000000  0.2143 ns/op     0 B/op  0 allocs/op
      PASS
      ok    github.com/go-ldap/ldif 3.329s
```

Without this (or similar patch), ldif marshaling is basically unusable for a reasonably sized directory.