### PR TITLE
add support for stream parsing LDIF entries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,7 @@
 module github.com/go-ldap/ldif
 
-go 1.14
+go 1.23
 
-require (
-	github.com/go-asn1-ber/asn1-ber v1.4.1 // indirect
-	github.com/go-ldap/ldap/v3 v3.1.7
-)
+require github.com/go-ldap/ldap/v3 v3.1.7
+
+require github.com/go-asn1-ber/asn1-ber v1.4.1 // indirect

--- a/ldif.go
+++ b/ldif.go
@@ -8,9 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"iter"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 
@@ -498,7 +498,7 @@ func readURLValue(val string) (string, error) {
 	if u.Scheme != "file" {
 		return "", fmt.Errorf("unsupported URL scheme %s", u.Scheme)
 	}
-	data, err := ioutil.ReadFile(toPath(u))
+	data, err := os.ReadFile(toPath(u))
 	if err != nil {
 		return "", fmt.Errorf("failed to read %s: %s", u.Path, err)
 	}

--- a/ldif.go
+++ b/ldif.go
@@ -91,6 +91,23 @@ func Unmarshal(r io.Reader, l *LDIF) (err error) {
 // The caller is responsible for closing the io.Reader if that is needed.
 func UnmarshalEntries(r io.Reader, l *LDIF) iter.Seq2[*Entry, error] {
 	return func(yield func(*Entry, error) bool) {
+		for e, err := range unmarshalEntries(r, l) {
+			if err == nil && e == nil {
+				// I couldn't find use-case where the entry and the error is both nil,
+				// but I saw helper functions to help avoid them,
+				// so I added this logic here, to skip nil entries
+				// while preserving Unmarshal's original behaviour.
+				continue
+			}
+			if !yield(e, err) {
+				return
+			}
+		}
+	}
+}
+
+func unmarshalEntries(r io.Reader, l *LDIF) iter.Seq2[*Entry, error] {
+	return func(yield func(*Entry, error) bool) {
 		if r == nil {
 			yield(nil, &ParseError{Line: 0, Message: "No reader present"})
 			return

--- a/ldif.go
+++ b/ldif.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"iter"
 	"net/url"
 	"strconv"
 	"strings"
@@ -77,70 +78,91 @@ func ParseWithControls(str string) (l *LDIF, err error) {
 // The caller is responsible for closing the io.Reader if that is
 // needed.
 func Unmarshal(r io.Reader, l *LDIF) (err error) {
-	if r == nil {
-		return &ParseError{Line: 0, Message: "No reader present"}
+	for entry, err := range UnmarshalEntries(r, l) {
+		if err != nil {
+			return err
+		}
+		l.Entries = append(l.Entries, entry)
 	}
-	curLine := 0
-	l.Version = 0
-	l.changeType = ""
-	isComment := false
+	return nil
+}
 
-	reader := bufio.NewReader(r)
+// UnmarshalEntries parses the LDIF from the given io.Reader and yield the individual entries during an iteration.
+// The caller is responsible for closing the io.Reader if that is needed.
+func UnmarshalEntries(r io.Reader, l *LDIF) iter.Seq2[*Entry, error] {
+	return func(yield func(*Entry, error) bool) {
+		if r == nil {
+			yield(nil, &ParseError{Line: 0, Message: "No reader present"})
+			return
+		}
 
-	var lines []string
-	var line, nextLine string
-	l.firstEntry = true
+		curLine := 0
+		l.Version = 0
+		l.changeType = ""
+		isComment := false
 
-	for {
-		curLine++
-		nextLine, err = reader.ReadString(lf)
-		nextLine = strings.TrimRight(nextLine, sep)
+		reader := bufio.NewReader(r)
 
-		switch err {
-		case nil, io.EOF:
-			switch len(nextLine) {
-			case 0:
-				if len(line) == 0 && err == io.EOF {
-					return nil
-				}
-				if len(line) == 0 && len(lines) == 0 {
-					continue
-				}
-				lines = append(lines, line)
-				entry, perr := l.parseEntry(lines)
-				if perr != nil {
-					return &ParseError{Line: curLine, Message: perr.Error()}
-				}
-				l.Entries = append(l.Entries, entry)
-				line = ""
-				lines = []string{}
-				if err == io.EOF {
-					return nil
-				}
-			default:
-				switch nextLine[0] {
-				case comment:
-					isComment = true
-					continue
+		var lines []string
+		var line, nextLine string
+		l.firstEntry = true
 
-				case space:
-					if isComment {
+		for {
+			curLine++
+			var err error
+			nextLine, err = reader.ReadString(lf)
+			nextLine = strings.TrimRight(nextLine, sep)
+
+			switch err {
+			case nil, io.EOF:
+				switch len(nextLine) {
+				case 0:
+					if len(line) == 0 && err == io.EOF {
+						return
+					}
+					if len(line) == 0 && len(lines) == 0 {
 						continue
 					}
-					line += nextLine[1:]
-					continue
-
-				default:
-					isComment = false
-					if len(line) != 0 {
-						lines = append(lines, line)
+					lines = append(lines, line)
+					entry, perr := l.parseEntry(lines)
+					if perr != nil {
+						yield(nil, &ParseError{Line: curLine, Message: perr.Error()})
+						return
 					}
-					line = nextLine
-					continue
+					if !yield(entry, nil) {
+						return
+					}
+					line = ""
+					lines = []string{}
+					if err == io.EOF {
+						return
+					}
+				default:
+					switch nextLine[0] {
+					case comment:
+						isComment = true
+						continue
+
+					case space:
+						if isComment {
+							continue
+						}
+						line += nextLine[1:]
+						continue
+
+					default:
+						isComment = false
+						if len(line) != 0 {
+							lines = append(lines, line)
+						}
+						line = nextLine
+						continue
+					}
 				}
+			default:
+				yield(nil, &ParseError{Line: curLine, Message: err.Error()})
+				return
 			}
-		default:
-			return &ParseError{Line: curLine, Message: err.Error()}
 		}
 	}
 }

--- a/ldif_test.go
+++ b/ldif_test.go
@@ -3,7 +3,6 @@ package ldif_test
 import (
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -256,7 +255,7 @@ func TestLDIFMultiSpace(t *testing.T) {
 }
 
 func TestLDIFURL(t *testing.T) {
-	f, err := ioutil.TempFile("", "ldifurl")
+	f, err := os.CreateTemp("", "ldifurl")
 	if err != nil {
 		t.Errorf("Failed to create temp file: %s", err)
 	}

--- a/ldif_test.go
+++ b/ldif_test.go
@@ -1,9 +1,13 @@
 package ldif_test
 
 import (
+	"errors"
+	"io"
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
+	"testing/iotest"
 
 	"github.com/go-ldap/ldap/v3"
 	"github.com/go-ldap/ldif"
@@ -39,6 +43,78 @@ func TestLDIFParseRFC2849Example(t *testing.T) {
 	if l.Entries[1].Entry.GetAttributeValues("sn")[0] != "Jensen" {
 		t.Errorf("RFC 2849 example: empty 'sn' in second entry")
 	}
+}
+
+func TestUnmarshalEntries(t *testing.T) {
+	t.Run("RFC 2849 example", func(t *testing.T) {
+		var (
+			source  = strings.NewReader(ldifRFC2849Example)
+			entries []*ldif.Entry
+		)
+		for e, err := range ldif.UnmarshalEntries(source, &ldif.LDIF{}) {
+			if err != nil {
+				t.Fatalf("unexpected error while unmarshaling ldif example: %s", err.Error())
+			}
+			entries = append(entries, e)
+		}
+		if len(entries) < 2 {
+			t.Fatalf("expected that after unmarshaling the entries, it should yield results")
+		}
+		second := entries[1]
+		if second.Entry.GetAttributeValues("sn")[0] != "Jensen" {
+			t.Fatal("RFC 2849 example: empty 'sn' in second entry")
+		}
+		if second.Entry.GetAttributeValues("sn")[0] != "Jensen" {
+			t.Fatal("RFC 2849 example: empty 'sn' in second entry")
+		}
+		if _, err := source.Read(make([]byte, 1)); !errors.Is(err, io.EOF) {
+			t.Fatal("RFC 2849 example: expected that reader is fully consumed")
+		}
+	})
+	t.Run("rainy", func(t *testing.T) {
+		t.Run("absent reader", func(t *testing.T) {
+			var (
+				err error
+				n   int
+			)
+			for _, got := range ldif.UnmarshalEntries(nil, &ldif.LDIF{}) {
+				n++
+				err = got
+			}
+			if n != 1 {
+				t.Fatalf("unexpected iteration count: %d", n)
+			}
+			var target *ldif.ParseError
+			if !errors.As(err, &target) {
+				t.Fatalf("unexpected error returned: %#v", err)
+			}
+			if target == nil {
+				t.Fatalf("ParseError was unexpectedly nil")
+			}
+			if *target == (ldif.ParseError{}) {
+				t.Fatalf("ParseError was unexpectedly empty")
+			}
+		})
+		t.Run("io reader error", func(t *testing.T) {
+			var (
+				expErr = errors.New("boom")
+				source = iotest.ErrReader(expErr)
+				ok     bool
+			)
+			for _, err := range ldif.UnmarshalEntries(source, &ldif.LDIF{}) {
+				ok = true
+				if err == nil {
+					t.Fatal("expected error but got nothing")
+				}
+				if !strings.Contains(err.Error(), expErr.Error()) {
+					t.Fatalf("unexpected error is returned: %#v", err)
+				}
+			}
+			if !ok {
+				t.Fatal("error is not propagated back from the iterator")
+			}
+		})
+	})
 }
 
 var ldifEmpty = `dn: uid=someone,dc=example,dc=org

--- a/ldif_test.go
+++ b/ldif_test.go
@@ -71,6 +71,19 @@ func TestUnmarshalEntries(t *testing.T) {
 			t.Fatal("RFC 2849 example: expected that reader is fully consumed")
 		}
 	})
+
+	t.Run("empty", func(t *testing.T) {
+		var source = strings.NewReader("")
+		for e, err := range ldif.UnmarshalEntries(source, &ldif.LDIF{}) {
+			if err != nil {
+				t.Fatalf("unexpected error while unmarshaling ldif example: %s", err.Error())
+			}
+			if e == nil {
+				t.Fatalf("unexpected nil entry: %s", err.Error())
+			}
+		}
+	})
+
 	t.Run("rainy", func(t *testing.T) {
 		t.Run("absent reader", func(t *testing.T) {
 			var (


### PR DESCRIPTION
When an LDIF file exceeds memory limits, processing it entry‑by‑entry will help bypass those constraints.

Changes:
- Unmarshal logic got refactored to not collect the entries in the LDIF.Entries field but rather yield back,
- For backwards compatibility, the change is exposed in the package as UnmarshalEntries, and the Unmarshal public behaviour remained untouched.
- New behaviour is documented through extended test coverage