### PR TITLE
Add support for streaming ldif output

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -22,12 +22,23 @@ var ErrMixed = errors.New("cannot mix change records and content records")
 // the fw parameter to something else than 0.
 // For a fold width < 0, no folding will be done, with 0, the default is used.
 func Marshal(l *LDIF) (data string, err error) {
+	var builder strings.Builder
+	err = MarshalStreaming(l, &builder)
+	if err != nil {
+		return "", err
+	}
+	return builder.String(), nil
+}
+
+func MarshalStreaming(l *LDIF, writer io.Writer) (err error) {
 	hasEntry := false
 	hasChange := false
 
-	var builder strings.Builder
 	if l.Version > 0 {
-		builder.WriteString("version: 1\n")
+		_, err := io.WriteString(writer, "version: 1\n")
+		if err != nil {
+			return err
+		}
 	}
 
 	fw := l.FoldWidth
@@ -40,13 +51,22 @@ func Marshal(l *LDIF) (data string, err error) {
 		case e.Add != nil:
 			hasChange = true
 			if hasEntry {
-				return "", ErrMixed
+				return ErrMixed
 			}
-			builder.WriteString(foldLine("dn: "+e.Add.DN, fw) + "\n")
-			builder.WriteString("changetype: add\n")
+
+			_, err := io.WriteString(writer, foldLine("dn: "+e.Add.DN, fw)+"\n")
+			if err != nil {
+				return err
+			}
+
+			_, err = io.WriteString(writer, "changetype: add\n")
+			if err != nil {
+				return err
+			}
+
 			for _, add := range e.Add.Attributes {
 				if len(add.Vals) == 0 {
-					return "", errors.New("changetype 'add' requires non empty value list")
+					return errors.New("changetype 'add' requires non empty value list")
 				}
 				for _, v := range add.Vals {
 					ev, t := encodeValue(v)
@@ -54,80 +74,137 @@ func Marshal(l *LDIF) (data string, err error) {
 					if t {
 						col = ":: "
 					}
-					builder.WriteString(foldLine(add.Type+col+ev, fw) + "\n")
+
+					_, err = io.WriteString(writer, foldLine(add.Type+col+ev, fw)+"\n")
+					if err != nil {
+						return err
+					}
 				}
 			}
 
 		case e.Del != nil:
 			hasChange = true
 			if hasEntry {
-				return "", ErrMixed
+				return ErrMixed
 			}
-			builder.WriteString(foldLine("dn: "+e.Del.DN, fw) + "\n")
-			builder.WriteString("changetype: delete\n")
+
+			_, err = io.WriteString(writer, foldLine("dn: "+e.Del.DN, fw)+"\n")
+			if err != nil {
+				return err
+			}
+
+			_, err = io.WriteString(writer, "changetype: delete\n")
+			if err != nil {
+				return err
+			}
 
 		case e.Modify != nil:
 			hasChange = true
 			if hasEntry {
-				return "", ErrMixed
+				return ErrMixed
 			}
-			builder.WriteString(foldLine("dn: "+e.Modify.DN, fw) + "\n")
-			builder.WriteString("changetype: modify\n")
+
+			_, err = io.WriteString(writer, foldLine("dn: "+e.Modify.DN, fw)+"\n")
+			if err != nil {
+				return err
+			}
+
+			_, err = io.WriteString(writer, "changetype: modify\n")
+			if err != nil {
+				return err
+			}
+
 			for _, mod := range e.Modify.Changes {
 				switch mod.Operation {
 				// add operation - https://tools.ietf.org/html/rfc4511#section-4.6
 				case 0:
 					if len(mod.Modification.Vals) == 0 {
-						return "", errors.New("changetype 'modify', op 'add' requires non empty value list")
+						return errors.New("changetype 'modify', op 'add' requires non empty value list")
 					}
 
-					builder.WriteString("add: " + mod.Modification.Type + "\n")
+					_, err = io.WriteString(writer, "add: "+mod.Modification.Type+"\n")
+					if err != nil {
+						return err
+					}
+
 					for _, v := range mod.Modification.Vals {
 						ev, t := encodeValue(v)
 						col := ": "
 						if t {
 							col = ":: "
 						}
-						builder.WriteString(foldLine(mod.Modification.Type+col+ev, fw) + "\n")
+
+						_, err = io.WriteString(writer, foldLine(mod.Modification.Type+col+ev, fw)+"\n")
+						if err != nil {
+							return err
+						}
 					}
-					builder.WriteString("-\n")
+					_, err = io.WriteString(writer, "-\n")
+					if err != nil {
+						return err
+					}
 				// delete operation - https://tools.ietf.org/html/rfc4511#section-4.6
 				case 1:
-					builder.WriteString("delete: " + mod.Modification.Type + "\n")
+					_, err = io.WriteString(writer, "delete: "+mod.Modification.Type+"\n")
+					if err != nil {
+						return err
+					}
+
 					for _, v := range mod.Modification.Vals {
 						ev, t := encodeValue(v)
 						col := ": "
 						if t {
 							col = ":: "
 						}
-						builder.WriteString(foldLine(mod.Modification.Type+col+ev, fw) + "\n")
+						_, err = io.WriteString(writer, foldLine(mod.Modification.Type+col+ev, fw)+"\n")
+						if err != nil {
+							return err
+						}
 					}
-					builder.WriteString("-\n")
+					_, err = io.WriteString(writer, "-\n")
+					if err != nil {
+						return err
+					}
 				// replace operation - https://tools.ietf.org/html/rfc4511#section-4.6
 				case 2:
 					if len(mod.Modification.Vals) == 0 {
-						return "", errors.New("changetype 'modify', op 'replace' requires non empty value list")
+						return errors.New("changetype 'modify', op 'replace' requires non empty value list")
 					}
-					builder.WriteString("replace: " + mod.Modification.Type + "\n")
+					_, err = io.WriteString(writer, "replace: "+mod.Modification.Type+"\n")
+					if err != nil {
+						return err
+					}
 					for _, v := range mod.Modification.Vals {
 						ev, t := encodeValue(v)
 						col := ": "
 						if t {
 							col = ":: "
 						}
-						builder.WriteString(foldLine(mod.Modification.Type+col+ev, fw) + "\n")
+
+						_, err = io.WriteString(writer, foldLine(mod.Modification.Type+col+ev, fw)+"\n")
+						if err != nil {
+							return err
+						}
 					}
-					builder.WriteString("-\n")
+					_, err = io.WriteString(writer, "-\n")
+					if err != nil {
+						return err
+					}
 				default:
-					return "", fmt.Errorf("invalid type %s in modify request", mod.Modification.Type)
+					return fmt.Errorf("invalid type %s in modify request", mod.Modification.Type)
 				}
 			}
 		default:
 			hasEntry = true
 			if hasChange {
-				return "", ErrMixed
+				return ErrMixed
 			}
-			builder.WriteString(foldLine("dn: "+e.Entry.DN, fw) + "\n")
+
+			_, err = io.WriteString(writer, foldLine("dn: "+e.Entry.DN, fw)+"\n")
+			if err != nil {
+				return err
+			}
+
 			for _, av := range e.Entry.Attributes {
 				for _, v := range av.Values {
 					ev, t := encodeValue(v)
@@ -135,13 +212,19 @@ func Marshal(l *LDIF) (data string, err error) {
 					if t {
 						col = ":: "
 					}
-					builder.WriteString(foldLine(av.Name+col+ev, fw) + "\n")
+					_, err = io.WriteString(writer, foldLine(av.Name+col+ev, fw)+"\n")
+					if err != nil {
+						return err
+					}
 				}
 			}
 		}
-		builder.WriteString("\n")
+		_, err = io.WriteString(writer, "\n")
+		if err != nil {
+			return err
+		}
 	}
-	return builder.String(), nil
+	return nil
 }
 
 func encodeValue(value string) (string, bool) {
@@ -193,11 +276,7 @@ func Dump(fh io.Writer, fw int, entries ...interface{}) error {
 		return err
 	}
 	l.FoldWidth = fw
-	str, err := Marshal(l)
-	if err != nil {
-		return err
-	}
-	_, err = fh.Write([]byte(str))
+	err = MarshalStreaming(l, fh)
 	return err
 }
 

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -3,6 +3,8 @@ package ldif_test
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -125,28 +127,86 @@ func nPeople(n int) ([]*ldap.Entry, string) {
 }
 
 func BenchmarkMarshalNEntries(b *testing.B) {
-	benchmarker := func(n int) {
-		b.Run(fmt.Sprintf("marshal %d", n), func(b *testing.B) {
+	benchmarker := func(n int, stream string, writeWith func(callback func(writer io.Writer, reader io.Reader) error) error) {
+		b.Run(fmt.Sprintf("marshal %d %s", n, stream), func(b *testing.B) {
 			entries, expected := nPeople(n)
 			ldifEntries := make([]*ldif.Entry, len(entries))
 			for i, entry := range entries {
 				ldifEntries[i] = &ldif.Entry{Entry: entry}
 			}
 			l := &ldif.LDIF{Entries: ldifEntries}
-			actual, err := ldif.Marshal(l)
+
+			err := writeWith(func(writer io.Writer, reader io.Reader) error {
+				err := ldif.MarshalStreaming(l, writer)
+				if err != nil {
+					return err
+				}
+
+				if seeker, ok := reader.(io.Seeker); ok {
+					_, err := seeker.Seek(0, io.SeekStart)
+					if err != nil {
+						return err
+					}
+				}
+
+				all, err := io.ReadAll(reader)
+				if err != nil {
+					return err
+				}
+
+				actual := string(all)
+
+				if actual != expected {
+					b.Errorf("expected: >>%s<<\nactual: >>%s<<\n", expected, actual)
+				}
+
+				return nil
+			})
+
 			if err != nil {
 				b.Errorf("Failed to marshal entry: %s", err)
-			}
-			if actual != expected {
-				b.Errorf("expected: >>%s<<\nactual: >>%s<<\n", expected, actual)
 			}
 		})
 	}
 
-	benchmarker(100)
-	benchmarker(1000)
-	benchmarker(10000)
-	benchmarker(100000)
+	writers := []struct {
+		name      string
+		writeWith func(callback func(writer io.Writer, reader io.Reader) error) error
+	}{
+		{
+			name: "file",
+			writeWith: func(callback func(writer io.Writer, reader io.Reader) error) error {
+				file, err := os.CreateTemp(os.TempDir(), "ldif_test")
+
+				if err != nil {
+					return err
+				}
+
+				err = callback(file, file)
+
+				if err != nil {
+					return err
+				}
+
+				return file.Close()
+			},
+		},
+		{
+			name: "bytebuffer",
+			writeWith: func(callback func(writer io.Writer, reader io.Reader) error) error {
+				var b bytes.Buffer
+				return callback(&b, &b)
+			},
+		},
+	}
+
+	for _, tt := range writers {
+		benchmarker(100, tt.name, tt.writeWith)
+		benchmarker(1000, tt.name, tt.writeWith)
+		benchmarker(10000, tt.name, tt.writeWith)
+		benchmarker(100000, tt.name, tt.writeWith)
+	}
+
 }
 
 func TestMarshalSingleEntry(t *testing.T) {


### PR DESCRIPTION
Large LDIFs would require a lot of memory for building the string in memory before writing to a file.

This implementation allows the caller to choose where to write the ldif (memory, file) and if they want to use a buffered writer or not.