### PR TITLE
fix: fix some RFC 2849 parsing and marshalling edge cases

### DIFF
--- a/changes_test.go
+++ b/changes_test.go
@@ -1,8 +1,10 @@
 package ldif_test
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/go-ldap/ldap/v3"
 	"github.com/go-ldap/ldif"
 )
 
@@ -69,6 +71,44 @@ replace: postaladdress
 delete: description
 -
 `
+
+// A control made of an OID and an optional criticality flag but no
+// controlValue (e.g. "control: <oid>" or "control: <oid> true") must parse: the
+// "true"/"false" token must be read as the criticality, not as a controlValue.
+func TestParseControlCriticality(t *testing.T) {
+	const tmpl = `version: 1
+dn: ou=x,dc=example,dc=com
+control: 2.16.840.1.113730.3.4.2%s
+changetype: delete
+`
+	cases := map[string]struct {
+		suffix          string
+		wantCriticality bool
+	}{
+		"absent": {"", false},
+		"true":   {" true", true},
+		"false":  {" false", false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			l, err := ldif.ParseWithControls(fmt.Sprintf(tmpl, tc.suffix))
+			if err != nil {
+				t.Fatalf("failed to parse control: %s", err)
+			}
+			ctrls := l.Entries[0].Del.Controls
+			if len(ctrls) != 1 {
+				t.Fatalf("expected 1 control, got %d", len(ctrls))
+			}
+			c, ok := ctrls[0].(*ldap.ControlManageDsaIT)
+			if !ok {
+				t.Fatalf("expected *ldap.ControlManageDsaIT, got %T", ctrls[0])
+			}
+			if c.Criticality != tc.wantCriticality {
+				t.Errorf("criticality = %v, want %v", c.Criticality, tc.wantCriticality)
+			}
+		})
+	}
+}
 
 func TestLDIFParseRFC2849Example6(t *testing.T) {
 	l, err := ldif.Parse(ldifRFC2849Example6)

--- a/ldif.go
+++ b/ldif.go
@@ -32,7 +32,6 @@ type Entry struct {
 type LDIF struct {
 	Entries    []*Entry
 	Version    int
-	changeType string
 	FoldWidth  int
 	Controls   bool
 	firstEntry bool
@@ -115,7 +114,6 @@ func unmarshalEntries(r io.Reader, l *LDIF) iter.Seq2[*Entry, error] {
 
 		curLine := 0
 		l.Version = 0
-		l.changeType = ""
 		isComment := false
 
 		reader := bufio.NewReader(r)
@@ -232,17 +230,18 @@ func (l *LDIF) parseEntry(lines []string) (entry *Entry, err error) {
 		return nil, err
 	}
 
+	var changeType string
 	if strings.HasPrefix(lines[0], "changetype:") {
 		_, val, err := l.parseLine(lines[0])
 		if err != nil {
 			return nil, err
 		}
-		l.changeType = val
+		changeType = val
 		if len(lines) > 1 {
 			lines = lines[1:]
 		}
 	}
-	switch l.changeType {
+	switch changeType {
 	case "":
 		if len(controls) != 0 {
 			return nil, errors.New("controls found without changetype")
@@ -322,10 +321,10 @@ func (l *LDIF) parseEntry(lines []string) (entry *Entry, err error) {
 		return &Entry{Modify: mod}, nil
 
 	case "moddn", "modrdn":
-		return nil, fmt.Errorf("unsupported changetype %s", l.changeType)
+		return nil, fmt.Errorf("unsupported changetype %s", changeType)
 
 	default:
-		return nil, fmt.Errorf("invalid changetype %s", l.changeType)
+		return nil, fmt.Errorf("invalid changetype %s", changeType)
 	}
 }
 
@@ -355,17 +354,18 @@ func (l *LDIF) parseLine(line string) (attr, val string, err error) {
 		return
 	}
 
-	if off > len(line)-2 {
-		err = errors.New("empty value")
-		// FIXME: this is allowed for some attributes, e.g. seeAlso
-		return
-	}
-
 	attr = line[0:off]
 	if err = validAttr(attr); err != nil {
 		attr = ""
 		val = ""
 		return
+	}
+
+	// A line of the form "attr:" with nothing after the colon is a
+	// zero-length value, which RFC 2849 (note 5) requires to be supported
+	// (e.g. "seeAlso:").
+	if off == len(line)-1 {
+		return attr, "", nil
 	}
 
 	switch line[off+1] {
@@ -418,17 +418,14 @@ func (l *LDIF) parseControls(lines []string) ([]ldap.Control, []string, error) {
 
 		if len(parts) > 1 {
 			switch parts[1] {
-			case "true":
-				criticality = true
+			case "true", "false":
+				criticality = parts[1] == "true"
 				if len(parts) > 2 {
-					parts[1] = parts[2]
-					parts = parts[0:2]
-				}
-			case "false":
-				criticality = false
-				if len(parts) > 2 {
-					parts[1] = parts[2]
-					parts = parts[0:2]
+					// a controlValue follows the criticality token
+					parts = []string{parts[0], parts[2]}
+				} else {
+					// criticality only, no controlValue
+					parts = parts[:1]
 				}
 			}
 		}

--- a/ldif_test.go
+++ b/ldif_test.go
@@ -134,10 +134,78 @@ cn:
 cn: Some User
 `
 
+// RFC 2849 note 5: a zero-length value is represented as "attr:" and MUST be
+// supported (e.g. "seeAlso:").
 func TestLDIFParseEmptyAttr(t *testing.T) {
-	_, err := ldif.Parse(ldifEmpty)
-	if err == nil {
-		t.Errorf("Did not fail to parse empty attribute")
+	l, err := ldif.Parse(ldifEmpty)
+	if err != nil {
+		t.Fatalf("Failed to parse empty attribute value: %s", err)
+	}
+	vals := l.Entries[0].Entry.GetAttributeValues("cn")
+	if len(vals) != 2 {
+		t.Fatalf("expected 2 cn values, got %d: %#v", len(vals), vals)
+	}
+	if vals[0] != "" {
+		t.Errorf("expected first cn value to be empty, got %q", vals[0])
+	}
+	if vals[1] != "Some User" {
+		t.Errorf("expected second cn value %q, got %q", "Some User", vals[1])
+	}
+}
+
+// RFC 2849 note 5 represents a zero-length value as "AttributeDescription ':'
+// FILL SEP", where FILL is *SPACE. So both "seeAlso:" and "seeAlso:   " denote
+// an empty value, and they exercise different branches of parseLine (the bare
+// colon-terminated line vs. the trailing-space path).
+func TestLDIFParseZeroLengthValue(t *testing.T) {
+	for name, in := range map[string]string{
+		"no fill":   "dn: uid=someone,dc=example,dc=org\nseeAlso:\nsn: Some One\n",
+		"with fill": "dn: uid=someone,dc=example,dc=org\nseeAlso:   \nsn: Some One\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			l, err := ldif.Parse(in)
+			if err != nil {
+				t.Fatalf("Failed to parse zero-length value: %s", err)
+			}
+			vals := l.Entries[0].Entry.GetAttributeValues("seeAlso")
+			if len(vals) != 1 || vals[0] != "" {
+				t.Errorf("expected a single empty seeAlso value, got %#v", vals)
+			}
+		})
+	}
+}
+
+var ldifChangeThenContent = `dn: cn=a,dc=example,dc=org
+changetype: add
+cn: a
+
+dn: cn=b,dc=example,dc=org
+cn: b
+sn: b
+`
+
+// A record without a changetype must be parsed as a content entry regardless of
+// what the previous record's changetype was: the parser must not carry the
+// changetype across records.
+func TestLDIFChangeTypeNotLeaked(t *testing.T) {
+	l, err := ldif.Parse(ldifChangeThenContent)
+	if err != nil {
+		t.Fatalf("Failed to parse: %s", err)
+	}
+	if l.Entries[0].Add == nil {
+		t.Fatalf("first record should be an add request")
+	}
+	if l.Entries[1].Add != nil {
+		t.Errorf("changetype leaked: second record parsed as an add request")
+	}
+	if l.Entries[1].Entry == nil {
+		t.Fatalf("second record should be a content entry, not %#v", l.Entries[1])
+	}
+	if dn := l.Entries[1].Entry.DN; dn != "cn=b,dc=example,dc=org" {
+		t.Errorf("wrong dn on second entry: %q", dn)
+	}
+	if cn := l.Entries[1].Entry.GetAttributeValue("cn"); cn != "b" {
+		t.Errorf("wrong cn on second entry: %q", cn)
 	}
 }
 

--- a/marshal.go
+++ b/marshal.go
@@ -228,13 +228,30 @@ func MarshalStreaming(l *LDIF, writer io.Writer) (err error) {
 }
 
 func encodeValue(value string) (string, bool) {
+	if value == "" {
+		return value, false
+	}
+
 	required := false
-	for _, r := range value {
-		if r < ' ' || r > '~' || value[len(value)-1:] == " " { // ~ = 0x7E, <DEL> = 0x7F
-			required = true
-			break
+	switch value[0] {
+	// SAFE-INIT-CHAR (RFC 2849): a value MUST be base64 encoded when it
+	// begins with SPACE, ':' or '<', otherwise it cannot be read back.
+	case ' ', ':', '<':
+		required = true
+	}
+	// A value that ends in SPACE SHOULD be base64 encoded (RFC 2849 note 8).
+	if value[len(value)-1] == ' ' {
+		required = true
+	}
+	if !required {
+		for _, r := range value {
+			if r < ' ' || r > '~' { // not a printable ASCII SAFE-CHAR
+				required = true
+				break
+			}
 		}
 	}
+
 	if !required {
 		return value, false
 	}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -2,6 +2,7 @@ package ldif_test
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"os"
@@ -279,6 +280,56 @@ description:: VGhlIFBlw7ZwbGUgw5ZyZ2FuaXphdGlvbg==
 	}
 	if res != entryLDIF {
 		t.Errorf("unexpected result: >>%s<<\n", res)
+	}
+}
+
+func TestMarshalLeadingTrailingSpace(t *testing.T) {
+	// Values that begin or end with a space must be base64 encoded so they
+	// survive a round-trip (RFC 2849 SAFE-INIT-CHAR / note 8).
+	entry := &ldap.Entry{
+		DN: "uid=someone,dc=example,dc=org",
+		Attributes: []*ldap.EntryAttribute{
+			{Name: "description", Values: []string{" leading"}},
+			{Name: "title", Values: []string{"trailing "}},
+			{Name: "colon", Values: []string{":value"}},
+			{Name: "lt", Values: []string{"<value"}},
+		},
+	}
+	l := &ldif.LDIF{Entries: []*ldif.Entry{{Entry: entry}}}
+	out, err := ldif.Marshal(l)
+	if err != nil {
+		t.Fatalf("Failed to marshal: %s", err)
+	}
+	// The leading-space value must be emitted with the base64 marker "::" and
+	// the correct encoding, not verbatim.
+	if strings.Contains(out, "description:  leading") {
+		t.Errorf("leading-space value was emitted verbatim:\n%s", out)
+	}
+	for _, wantLine := range []string{
+		"description:: " + base64.StdEncoding.EncodeToString([]byte(" leading")),
+		"title:: " + base64.StdEncoding.EncodeToString([]byte("trailing ")),
+		"colon:: " + base64.StdEncoding.EncodeToString([]byte(":value")),
+		"lt:: " + base64.StdEncoding.EncodeToString([]byte("<value")),
+	} {
+		if !strings.Contains(out, wantLine) {
+			t.Errorf("expected %q in output, got:\n%s", wantLine, out)
+		}
+	}
+
+	l2, err := ldif.Parse(out)
+	if err != nil {
+		t.Fatalf("Failed to re-parse marshalled output: %s\n%s", err, out)
+	}
+	got := l2.Entries[0].Entry
+	for attr, want := range map[string]string{
+		"description": " leading",
+		"title":       "trailing ",
+		"colon":       ":value",
+		"lt":          "<value",
+	} {
+		if v := got.GetAttributeValue(attr); v != want {
+			t.Errorf("%s lost in round-trip: got %q, want %q", attr, v, want)
+		}
 	}
 }
 


### PR DESCRIPTION
fixes several RFC 2849 conformance issues in the parser/marshaller:

- accepts zero length attribute values (i.e. `attr:`) - Fixes #21. See RFC 2849 note 5.
- parses controls with criticality but no controlValue (`control: <oid> true`) - The RFC grammar defines `criticality` and `controlValue` as separate optional fields. Example 7 from the RFC includes an example of this using Tree Delete Control. 
- base64 encode certain special characters during marshalling - RFC 2849 note 4 requires base64 encoding for values that begin with a character outside SAFE-INIT_CHAR like a leading space or a `:`. Note 8 additionally states that values ending with space SHOULD be base64

Please let me know if these changes are useful & if there are any questions/concerns/fixes I should make. Thanks :) 