### PR TITLE
fix: prevent nil pointer panic in Apply for content entries

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -19,7 +19,7 @@ func (l *LDIF) Apply(conn ldap.Client, continueOnErr bool) error {
 	for _, entry := range l.Entries {
 		switch {
 		case entry.Entry != nil:
-			add := ldap.NewAddRequest(entry.Entry.DN, entry.Add.Controls)
+			add := ldap.NewAddRequest(entry.Entry.DN, nil)
 			for _, attr := range entry.Entry.Attributes {
 				add.Attribute(attr.Name, attr.Values)
 			}

--- a/apply_test.go
+++ b/apply_test.go
@@ -1,0 +1,81 @@
+package ldif_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/go-ldap/ldap/v3"
+	"github.com/go-ldap/ldif"
+)
+
+// recordingConn records the requests passed to it and satisfies ldap.Client
+// via an embedded nil interface (only the methods Apply calls are implemented).
+type recordingConn struct {
+	ldap.Client
+	adds    []*ldap.AddRequest
+	dels    []*ldap.DelRequest
+	mods    []*ldap.ModifyRequest
+	failAdd bool
+}
+
+func (c *recordingConn) Add(r *ldap.AddRequest) error {
+	c.adds = append(c.adds, r)
+	if c.failAdd {
+		return errors.New("boom")
+	}
+	return nil
+}
+
+func (c *recordingConn) Del(r *ldap.DelRequest) error {
+	c.dels = append(c.dels, r)
+	return nil
+}
+
+func (c *recordingConn) Modify(r *ldap.ModifyRequest) error {
+	c.mods = append(c.mods, r)
+	return nil
+}
+
+// A content entry must be applied as an Add without panicking.
+func TestApplyContentEntry(t *testing.T) {
+	l, err := ldif.Parse("dn: uid=someone,dc=example,dc=org\ncn: Someone\n")
+	if err != nil {
+		t.Fatalf("parse: %s", err)
+	}
+	conn := &recordingConn{}
+	if err := l.Apply(conn, false); err != nil {
+		t.Fatalf("apply: %s", err)
+	}
+	if len(conn.adds) != 1 {
+		t.Fatalf("expected 1 add, got %d", len(conn.adds))
+	}
+	if conn.adds[0].DN != "uid=someone,dc=example,dc=org" {
+		t.Errorf("wrong DN: %q", conn.adds[0].DN)
+	}
+	if got := conn.adds[0].Attributes[0].Vals[0]; got != "Someone" {
+		t.Errorf("wrong cn: %q", got)
+	}
+}
+
+// continueOnErr must skip failures instead of returning them.
+func TestApplyContinueOnErr(t *testing.T) {
+	l, err := ldif.Parse("dn: uid=a,dc=example,dc=org\ncn: A\n\ndn: uid=b,dc=example,dc=org\ncn: B\n")
+	if err != nil {
+		t.Fatalf("parse: %s", err)
+	}
+	conn := &recordingConn{failAdd: true}
+	if err := l.Apply(conn, true); err != nil {
+		t.Fatalf("apply with continueOnErr should not return: %s", err)
+	}
+	if len(conn.adds) != 2 {
+		t.Errorf("expected both adds attempted, got %d", len(conn.adds))
+	}
+
+	conn = &recordingConn{failAdd: true}
+	if err := l.Apply(conn, false); err == nil {
+		t.Error("expected error without continueOnErr")
+	}
+	if len(conn.adds) != 1 {
+		t.Errorf("expected to stop after first failure, got %d adds", len(conn.adds))
+	}
+}

--- a/marshal.go
+++ b/marshal.go
@@ -283,8 +283,7 @@ func foldLine(line string, fw int) (folded string) {
 // Dump writes the given entries to the io.Writer.
 //
 // The entries argument can be *ldap.Entry or a mix of *ldap.AddRequest,
-// *ldap.DelRequest, *ldap.ModifyRequest and *ldap.ModifyDNRequest or slices
-// of any of those.
+// *ldap.DelRequest and *ldap.ModifyRequest or slices of any of those.
 //
 // See Marshal() for the fw argument.
 func Dump(fh io.Writer, fw int, entries ...interface{}) error {
@@ -300,8 +299,7 @@ func Dump(fh io.Writer, fw int, entries ...interface{}) error {
 // ToLDIF puts the given arguments in an LDIF struct and returns it.
 //
 // The entries argument can be *ldap.Entry or a mix of *ldap.AddRequest,
-// *ldap.DelRequest, *ldap.ModifyRequest and *ldap.ModifyDNRequest or slices
-// of any of those.
+// *ldap.DelRequest and *ldap.ModifyRequest or slices of any of those.
 func ToLDIF(entries ...interface{}) (*LDIF, error) {
 	l := &LDIF{}
 	for _, e := range entries {

--- a/path.go
+++ b/path.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package ldif


### PR DESCRIPTION
## Problem

`LDIF.Apply` panics on any content entry, which is its primary documented use ("All `*ldap.Entry` are converted to an `*ldap.AddRequest`"). In the `entry.Entry != nil` branch it read `entry.Add.Controls`, but `entry.Add` is always `nil` for a content entry, so this is an unconditional nil pointer dereference.

```go
case entry.Entry != nil:
    add := ldap.NewAddRequest(entry.Entry.DN, entry.Add.Controls) // entry.Add == nil -> panic
```

## Fix

Content entries carry no controls, so pass `nil`:

```go
add := ldap.NewAddRequest(entry.Entry.DN, nil)
```

## Also in this PR

- **Tests for `Apply`** — it had no coverage before. Added the content-entry path plus `continueOnErr` true/false behavior (`apply_test.go`).
- **Doc fix** — `ToLDIF`/`Dump` comments claimed `*ldap.ModifyDNRequest` input is accepted, but `ToLDIF` doesn't handle it (returns "unsupported type"). Removed the claim; matches the README note that moddn/modrdn are unsupported.
- **Build constraint** — added the modern `//go:build !windows` line to `path.go` alongside the legacy `// +build` tag, so `gofmt` / `make fmt` pass on a clean checkout.

All existing tests pass; `go vet` and `gofmt -l` are clean.